### PR TITLE
Include proxy (CONNECT)

### DIFF
--- a/src/Platform_unix.cpp
+++ b/src/Platform_unix.cpp
@@ -117,6 +117,7 @@ void Platform::setThreadPriority(int priority)
 
     setpriority(PRIO_PROCESS, 0, prio);
 
+#ifdef SCHED_IDLE
     if (priority == 0) {
         sched_param param;
         param.sched_priority = 0;
@@ -125,4 +126,5 @@ void Platform::setThreadPriority(int priority)
             sched_setscheduler(0, SCHED_BATCH, &param);
         }
     }
+#endif
 }

--- a/src/config.json
+++ b/src/config.json
@@ -8,12 +8,18 @@
     "coin": "xmr",
     "custom-diff": 0,
     "syslog": false,
+    "debug": false,
     "verbose": false,
     "colors": true,
     "workers": true,
     "pools": [
         {
             "url": "pool.minemonero.pro:5555",
+            "user": "",
+            "pass": "x"
+        },
+        {
+            "url": "pool.minemonero.pro:5555@localhost:8080",
             "user": "",
             "pass": "x"
         }

--- a/src/net/Client.cpp
+++ b/src/net/Client.cpp
@@ -274,7 +274,7 @@ int Client::resolve(const char *host)
 int64_t Client::send(size_t size)
 {
     LOG_DEBUG("[%s:%u] send (%d bytes): \"%s\"", m_url.host(), m_url.port(), size, m_sendBuf);
-    if (state() != ConnectedState || !uv_is_writable(m_stream)) {
+    if ((state() != ConnectedState && state() != ProxingState) || !uv_is_writable(m_stream)) {
         LOG_DEBUG_ERR("[%s:%u] send failed, invalid state: %d", m_url.host(), m_url.port(), m_state);
         return -1;
     }
@@ -328,6 +328,29 @@ void Client::connect(struct sockaddr *addr)
     uv_tcp_connect(req, m_socket, reinterpret_cast<const sockaddr*>(addr), Client::onConnect);
 }
 
+void Client::prelogin()
+{
+    if (m_url.proxyHost())
+    {
+        setState (ProxingState);
+        const std::string buffer = std::string ("CONNECT ") + m_url.finalHost() + " HTTP/1.1\r\n" +
+                                    "Host: " + m_url.finalHost() + ":" + std::to_string (m_url.finalPort()) +
+                                    "\r\n";
+        const size_t size = buffer.size();
+        LOG_INFO ("Prelogin send (%d bytes): \"%s\"", size, m_sendBuf);
+
+        memcpy (m_sendBuf, buffer.c_str(), size);
+        m_sendBuf[size]     = '\n';
+        m_sendBuf[size + 1] = '\0';
+
+        send (size + 1);
+    }
+    else
+    {
+        setState (ConnectedState);
+        login();
+    }
+}
 
 void Client::login()
 {
@@ -565,12 +588,11 @@ void Client::onConnect(uv_connect_t *req, int status)
 
     client->m_stream = static_cast<uv_stream_t*>(req->handle);
     client->m_stream->data = req->data;
-    client->setState(ConnectedState);
 
     uv_read_start(client->m_stream, Client::onAllocBuffer, Client::onRead);
     delete req;
 
-    client->login();
+    client->prelogin();
 }
 
 
@@ -587,6 +609,21 @@ void Client::onRead(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
 
     if ((size_t) nread > (sizeof(m_buf) - 8 - client->m_recvBufPos)) {
         return client->close();
+    }
+
+    if (client->state() == ProxingState)
+    {
+        const char* const content = buf->base;
+        LOG_DEBUG("[%s:%u] received from proxy (%d bytes): \"%s\"",
+                  client->m_url.host(), client->m_url.port(),
+                  nread, content);
+
+        if(content == strstr(content, "HTTP/1.1 200"))
+        {
+            client->setState(ConnectedState);
+            client->login();
+        }
+        return;
     }
 
     client->m_recvBufPos += nread;

--- a/src/net/Client.h
+++ b/src/net/Client.h
@@ -46,6 +46,7 @@ public:
         UnconnectedState,
         HostLookupState,
         ConnectingState,
+        ProxingState,
         ConnectedState,
         ClosingState
     };
@@ -81,6 +82,7 @@ private:
     int64_t send(size_t size);
     void close();
     void connect(struct sockaddr *addr);
+    void prelogin();
     void login();
     void parse(char *line, size_t len);
     void parseNotification(const char *method, const rapidjson::Value &params, const rapidjson::Value &error);

--- a/src/net/Url.h
+++ b/src/net/Url.h
@@ -34,6 +34,7 @@ public:
     constexpr static const char *kDefaultPassword = "x";
     constexpr static const char *kDefaultUser     = "x";
     constexpr static uint16_t kDefaultPort        = 3333;
+    constexpr static uint16_t kDefaultProxyPort   = 8080;
 
     Url();
     Url(const char *url);
@@ -42,10 +43,15 @@ public:
 
     inline bool isKeepAlive() const          { return m_keepAlive; }
     inline bool isValid() const              { return m_host && m_port > 0; }
-    inline const char *host() const          { return m_host; }
+    inline const char *host() const          { return isProxyed() ? proxyHost() : finalHost(); }
     inline const char *password() const      { return m_password ? m_password : kDefaultPassword; }
     inline const char *user() const          { return m_user ? m_user : kDefaultUser; }
-    inline uint16_t port() const             { return m_port; }
+    inline uint16_t port() const             { return isProxyed() ? proxyPort() : finalPort(); }
+    inline bool isProxyed() const            { return proxyHost(); }
+    inline const char* finalHost() const     { return m_host; }
+    inline uint16_t finalPort() const        { return m_port;}
+    inline const char* proxyHost() const     { return m_proxy_host; }
+    inline uint16_t proxyPort() const        { return m_proxy_port; }
     inline void setKeepAlive(bool keepAlive) { m_keepAlive = keepAlive; }
     inline void setNicehash(bool nicehash)   { m_nicehash = nicehash; }
 
@@ -64,6 +70,8 @@ private:
     char *m_password;
     char *m_user;
     uint16_t m_port;
+    char* m_proxy_host;
+    uint16_t m_proxy_port;
 };
 
 #endif /* __URL_H__ */


### PR DESCRIPTION
The 'config.json' and the '-o' command option allow to include a proxy:
poolHost[:poolPort[@proxyHost[:proxyPort]].

> XMR: _433hhduFBtwVXtQiTTTeqyZsB36XaBLJB6bcQfnqqMs5RJitdpi8xBN21hWiEfuPp2hytmf1cshgK5Grgo6QUvLZCP2QSMi_