### PR TITLE
Allow to use proxy

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,7 @@
 {
     "background": false,
     "log-file": null,
+    "user-agent": "",
     "access-log-file": null,
     "retries": 5,
     "retry-pause": 5,
@@ -8,22 +9,24 @@
     "coin": "xmr",
     "custom-diff": 0,
     "syslog": false,
+    "debug": false,
     "verbose": false,
     "colors": true,
     "workers": true,
     "pools": [
         {
-            "url": "pool.minemonero.pro:5555",
-            "user": "",
-            "pass": "x"
+            "url": "pool.minemonero.pro:3333",                   // ---------------  URL of mining server
+        /*  "url": "pool.minemonero.pro:443@localhost:8080",*/   // ---------------  URL of mining server over HTTP (CONNECT) proxy
+        /*  "url": "pool.minemonero.pro:7777#secret_keystream",*/                 // URL of mining xmrig-proxy with encrypted support
+        /*  "url": "pool.minemonero.pro:8080#secret_keystream@localhost:8080",*/  // URL of mining xmrig-proxy with encrypted support over HTTP (CONNECT) proxy
+            "user": "",                        // username for mining server
+            "pass": "x",                       // password for mining server
+            "keepalive": true,                 // send keepalived for prevent timeout (need pool support)
+            "nicehash": false                  // enable nicehash/xmrig-proxy support
         }
     ],
     "bind": [
-        "0.0.0.0:3333"
-    ],
-    "api": {
-        "port": 0,
-        "access-token": null,
-        "worker-id": null
-    }
+        "0.0.0.0:8088",                 // listen on port 8088 in plain-text
+        "0.0.0.0:8888#secret_keystream" // listen on port 8888 with encrpyt-text
+    ]
 }

--- a/src/net/Client.cpp
+++ b/src/net/Client.cpp
@@ -55,6 +55,8 @@ int64_t Client::m_sequence = 1;
 
 Client::Client(int id, const char *agent, IClientListener *listener) :
     m_quiet(false),
+    m_keystream(),
+    m_encrypted(false),
     m_agent(agent),
     m_listener(listener),
     m_id(id),
@@ -68,6 +70,7 @@ Client::Client(int id, const char *agent, IClientListener *listener) :
 {
     memset(m_ip, 0, sizeof(m_ip));
     memset(&m_hints, 0, sizeof(m_hints));
+    memset(m_keystream, 0, sizeof(m_keystream));
 
     m_resolver.data = this;
 
@@ -126,6 +129,16 @@ void Client::setUrl(const Url *url)
 {
     if (!url || !url->isValid()) {
         return;
+    }
+
+    if (url->hasKeystream())
+    {
+        url->copyKeystream(m_keystream, sizeof(m_keystream));
+        m_encrypted = true;
+    }
+    else
+    {
+        m_encrypted = false;
     }
 
     m_url = url;
@@ -271,14 +284,30 @@ int Client::resolve(const char *host)
 }
 
 
-int64_t Client::send(size_t size)
+int64_t Client::send(size_t size, const bool encrypted)
 {
     LOG_DEBUG("[%s:%u] send (%d bytes): \"%s\"", m_url.host(), m_url.port(), size, m_sendBuf);
-    if (state() != ConnectedState || !uv_is_writable(m_stream)) {
+    if ((state() != ConnectedState && state() != ProxingState) || !uv_is_writable(m_stream)) {
         LOG_DEBUG_ERR("[%s:%u] send failed, invalid state: %d", m_url.host(), m_url.port(), m_state);
         return -1;
     }
 
+    if(encrypted && m_encrypted)
+    {
+        // Encrypt
+        for(size_t i = 0; i < std::min(size, sizeof(m_keystream)); ++i)
+        {
+            m_sendBuf[i] ^= m_keystream[i];
+        }
+
+		char * send_encr_hex = static_cast<char*>(malloc(size * 2 + 1));
+		memset(send_encr_hex, 0, size * 2 + 1);
+		Job::toHex((const unsigned char*)m_sendBuf, size, send_encr_hex);
+		send_encr_hex[size * 2] = '\0';
+		LOG_DEBUG("[%s:%u] send encr. (%d bytes): 0x\"%s\"", m_url.host(), m_url.port(), size, send_encr_hex);
+		free(send_encr_hex);
+    }
+    
     uv_buf_t buf = uv_buf_init(m_sendBuf, (unsigned int) size);
 
     if (uv_try_write(m_stream, &buf, 1) < 0) {
@@ -328,6 +357,27 @@ void Client::connect(struct sockaddr *addr)
     uv_tcp_connect(req, m_socket, reinterpret_cast<const sockaddr*>(addr), Client::onConnect);
 }
 
+void Client::prelogin()
+{
+    if (m_url.proxyHost())
+    {
+        setState (ProxingState);
+        const std::string buffer = std::string ("CONNECT ") + m_url.finalHost() + ":" + std::to_string(m_url.finalPort()) + " HTTP/1.1\n";
+
+        const size_t size = buffer.size();
+        memcpy (m_sendBuf, buffer.c_str(), size);
+        m_sendBuf[size]     = '\n';
+        m_sendBuf[size + 1] = '\0';
+
+        LOG_DEBUG("Prelogin send (%d bytes): \"%s\"", size, m_sendBuf);
+        send (size + 1, false);
+    }
+    else
+    {
+        setState (ConnectedState);
+        login();
+    }
+}
 
 void Client::login()
 {
@@ -565,12 +615,11 @@ void Client::onConnect(uv_connect_t *req, int status)
 
     client->m_stream = static_cast<uv_stream_t*>(req->handle);
     client->m_stream->data = req->data;
-    client->setState(ConnectedState);
 
     uv_read_start(client->m_stream, Client::onAllocBuffer, Client::onRead);
     delete req;
 
-    client->login();
+    client->prelogin();
 }
 
 
@@ -589,11 +638,42 @@ void Client::onRead(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
         return client->close();
     }
 
+    if (client->state() == ProxingState)
+    {
+        const char* const content = buf->base;
+        LOG_DEBUG("[%s:%u] received from proxy (%d bytes): \"%s\"",
+                  client->m_url.host(), client->m_url.port(),
+                  nread, content);
+
+        if(content == strstr(content, "HTTP/1.1 200"))
+        {
+            LOG_INFO("[%s:%u] Proxy connected to %s:%u!", client->m_url.host(), client->m_url.port(), client->m_url.finalHost(), client->m_url.finalPort());
+            client->setState(ConnectedState);
+            client->login();
+        }
+        return;
+    }
+
     client->m_recvBufPos += nread;
 
     char* end;
     char* start = buf->base;
     size_t remaining = client->m_recvBufPos;
+
+    if(client->m_encrypted)
+    {
+        char * read_encr_hex = static_cast<char*>(malloc(nread * 2 + 1));
+        memset(read_encr_hex, 0, nread * 2 + 1);
+        Job::toHex((const unsigned char*)start, nread, read_encr_hex);
+        LOG_DEBUG("[%s] read encr. (%d bytes): 0x\"%s\"", client->m_ip, nread, read_encr_hex);
+        free(read_encr_hex);
+
+        // DeEncrypt
+        for(int i = 0; i < (int)nread; ++i)
+        {
+            start[i] ^= client->m_keystream[i];
+        }
+    }
 
     while ((end = static_cast<char*>(memchr(start, '\n', remaining))) != nullptr) {
         end++;

--- a/src/net/Client.h
+++ b/src/net/Client.h
@@ -46,6 +46,7 @@ public:
         UnconnectedState,
         HostLookupState,
         ConnectingState,
+        ProxingState,
         ConnectedState,
         ClosingState
     };
@@ -78,9 +79,10 @@ private:
     bool parseJob(const rapidjson::Value &params, int *code);
     bool parseLogin(const rapidjson::Value &result, int *code);
     int resolve(const char *host);
-    int64_t send(size_t size);
+    int64_t send(size_t size, const bool encrypted = true);
     void close();
     void connect(struct sockaddr *addr);
+    void prelogin();
     void login();
     void parse(char *line, size_t len);
     void parseNotification(const char *method, const rapidjson::Value &params, const rapidjson::Value &error);
@@ -104,6 +106,8 @@ private:
     char m_ip[17];
     char m_rpcId[64];
     char m_sendBuf[768];
+    char m_keystream[sizeof(m_sendBuf)];
+    bool m_encrypted;
     const char *m_agent;
     IClientListener *m_listener;
     int m_id;

--- a/src/net/Url.cpp
+++ b/src/net/Url.cpp
@@ -24,6 +24,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <algorithm>
 
 
 #include "net/Url.h"
@@ -40,7 +41,10 @@ Url::Url() :
     m_host(nullptr),
     m_password(nullptr),
     m_user(nullptr),
-    m_port(kDefaultPort)
+    m_port(kDefaultPort),
+    m_proxy_host(nullptr),
+    m_proxy_port(kDefaultProxyPort),
+    m_keystream(nullptr)
 {
 }
 
@@ -62,7 +66,10 @@ Url::Url(const char *url) :
     m_host(nullptr),
     m_password(nullptr),
     m_user(nullptr),
-    m_port(kDefaultPort)
+    m_port(kDefaultPort),
+    m_proxy_host(nullptr),
+    m_proxy_port(kDefaultProxyPort),
+    m_keystream(nullptr)
 {
     parse(url);
 }
@@ -73,7 +80,10 @@ Url::Url(const char *host, uint16_t port, const char *user, const char *password
     m_nicehash(nicehash),
     m_password(password ? strdup(password) : nullptr),
     m_user(user ? strdup(user) : nullptr),
-    m_port(port)
+    m_port(port),
+    m_proxy_host(nullptr),
+    m_proxy_port(kDefaultProxyPort),
+    m_keystream(nullptr)
 {
     m_host = strdup(host);
 }
@@ -84,6 +94,8 @@ Url::~Url()
     free(m_host);
     free(m_password);
     free(m_user);
+    free(m_proxy_host);
+    free(m_keystream);
 }
 
 
@@ -91,7 +103,6 @@ bool Url::isNicehash() const
 {
     return isValid() && (m_nicehash || strstr(m_host, ".nicehash.com"));
 }
-
 
 bool Url::parse(const char *url)
 {
@@ -121,7 +132,44 @@ bool Url::parse(const char *url)
     memcpy(m_host, base, size - 1);
     m_host[size - 1] = '\0';
 
+    const char* proxy = strchr(port, '@');
+    const char* keystream = strchr(port, '#');
+    if(keystream)
+    {
+        ++keystream;
+        if(!proxy)
+        {
+            m_keystream = strdup(keystream);
+        }
+        else
+        {
+            const size_t keystreamsize = proxy - keystream;
+            m_keystream = static_cast<char*>(malloc (keystreamsize + 1));
+            m_keystream[keystreamsize] = '\0';
+            memcpy(m_keystream, keystream, keystreamsize);
+        }
+    }
+
     m_port = (uint16_t) strtol(port, nullptr, 10);
+    if (!proxy) {
+        m_port = (uint16_t) strtol(port, nullptr, 10);
+        return true;
+    }
+    
+    ++proxy;
+
+    const char* proxyport = strchr(proxy, ':');
+    if (!port) {
+        m_proxy_host = strdup(proxy);
+        return false;
+    }
+
+    const size_t proxysize = proxyport++ - proxy + 1;
+    m_proxy_host = static_cast<char*>(malloc (proxysize));
+    memcpy(m_proxy_host, proxy, proxysize - 1);
+    m_proxy_host[proxysize - 1] = '\0';
+    m_proxy_port = (uint16_t) strtol(proxyport, nullptr, 10);
+
     return true;
 }
 
@@ -165,18 +213,46 @@ void Url::setUser(const char *user)
     m_user = strdup(user);
 }
 
+void Url::copyKeystream(char *keystreamDest, const size_t keystreamLen) const
+{
+    if(hasKeystream())
+    {
+        memset(keystreamDest, 1, keystreamLen);
+        memcpy(keystreamDest, m_keystream, std::min(keystreamLen, strlen(m_keystream)));
+    }
+}
 
 Url &Url::operator=(const Url *other)
 {
     m_keepAlive = other->m_keepAlive;
     m_nicehash  = other->m_nicehash;
     m_port      = other->m_port;
+    m_proxy_port = other->m_proxy_port;
 
     free(m_host);
     m_host = strdup(other->m_host);
 
+    free (m_proxy_host);
+    if(other->m_proxy_host)
+    {
+        m_proxy_host = strdup (other->m_proxy_host);
+    }
+    else
+    {
+        m_proxy_host = nullptr;
+    }
+
     setPassword(other->m_password);
     setUser(other->m_user);
 
+    free (m_keystream);
+    if(other->m_keystream)
+    {
+        m_keystream = strdup (other->m_keystream);
+    }
+    else
+    {
+        m_keystream = nullptr;
+    }
     return *this;
 }

--- a/src/net/Url.h
+++ b/src/net/Url.h
@@ -34,6 +34,7 @@ public:
     constexpr static const char *kDefaultPassword = "x";
     constexpr static const char *kDefaultUser     = "x";
     constexpr static uint16_t kDefaultPort        = 3333;
+    constexpr static uint16_t kDefaultProxyPort   = 8080;
 
     Url();
     Url(const char *url);
@@ -42,10 +43,16 @@ public:
 
     inline bool isKeepAlive() const          { return m_keepAlive; }
     inline bool isValid() const              { return m_host && m_port > 0; }
-    inline const char *host() const          { return m_host; }
+    inline bool hasKeystream() const         { return m_keystream; }
+    inline const char *host() const          { return isProxyed() ? proxyHost() : finalHost(); }
     inline const char *password() const      { return m_password ? m_password : kDefaultPassword; }
     inline const char *user() const          { return m_user ? m_user : kDefaultUser; }
-    inline uint16_t port() const             { return m_port; }
+    inline uint16_t port() const             { return isProxyed() ? proxyPort() : finalPort(); }
+    inline bool isProxyed() const            { return proxyHost(); }
+    inline const char* finalHost() const     { return m_host; }
+    inline uint16_t finalPort() const        { return m_port; }
+    inline const char* proxyHost() const     { return m_proxy_host; }
+    inline uint16_t proxyPort() const        { return m_proxy_port; }
     inline void setKeepAlive(bool keepAlive) { m_keepAlive = keepAlive; }
     inline void setNicehash(bool nicehash)   { m_nicehash = nicehash; }
 
@@ -54,6 +61,7 @@ public:
     bool setUserpass(const char *userpass);
     void setPassword(const char *password);
     void setUser(const char *user);
+    void copyKeystream(char *keystreamDest, const size_t keystreamLen) const;
 
     Url &operator=(const Url *other);
 
@@ -64,6 +72,9 @@ private:
     char *m_password;
     char *m_user;
     uint16_t m_port;
+    char* m_proxy_host;
+    uint16_t m_proxy_port;
+    char* m_keystream;
 };
 
 #endif /* __URL_H__ */

--- a/src/proxy/Addr.h
+++ b/src/proxy/Addr.h
@@ -38,13 +38,28 @@ public:
 
     inline Addr() :
         m_host(nullptr),
-        m_port(kDefaultPort)
+        m_port(kDefaultPort),
+        m_keystream(nullptr)
     {}
-
+        
+    inline Addr(const Addr * const other)
+    {
+        m_port = other->m_port;
+        m_host = strdup(other->m_host);
+        if(other->m_keystream)
+        {
+            m_keystream = strdup (other->m_keystream);
+        }
+        else
+        {
+            m_keystream = nullptr;
+        }
+    }
 
     inline Addr(const char *addr) :
         m_host(nullptr),
-        m_port(kDefaultPort)
+        m_port(kDefaultPort),
+        m_keystream(nullptr)
     {
         if (!addr) {
             return;
@@ -62,6 +77,12 @@ public:
         m_host[size - 1] = '\0';
 
         m_port = (uint16_t) strtol(port, nullptr, 10);
+
+        const char* keystream = strchr(port, '#');
+        if(keystream)
+        {
+            m_keystream = strdup(keystream + 1);
+        }
     }
 
 
@@ -74,10 +95,20 @@ public:
     inline bool isValid() const     { return m_host && m_port > 0; }
     inline const char *host() const { return m_host; }
     inline uint16_t port() const    { return m_port; }
+    inline bool hasKeystream() const         { return m_keystream; }
+    void copyKeystream(char *keystreamDest, const size_t keystreamLen) const
+    {
+        if(m_keystream)
+        {
+            memset(keystreamDest, 1, keystreamLen);
+            memcpy(keystreamDest, m_keystream, std::min(keystreamLen, strlen(m_keystream)));
+        }
+    }
 
 private:
     char *m_host;
     uint16_t m_port;
+    char* m_keystream;
 };
 
 #endif /* __ADDR_H__ */

--- a/src/proxy/Miner.h
+++ b/src/proxy/Miner.h
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <uv.h>
 
+#include "proxy/Addr.h"
 
 #include "rapidjson/fwd.h"
 
@@ -47,7 +48,7 @@ public:
         ClosingState
     };
 
-    Miner();
+    Miner(const Addr &addr);
     ~Miner();
     bool accept(uv_stream_t *server);
     void replyWithError(int64_t id, const char *message);
@@ -78,7 +79,7 @@ private:
     void heartbeat();
     void parse(char *line, size_t len);
     void send(const char *data, int size);
-    void send(int size);
+    void send(int size, const bool encrypted = true);
     void setState(State state);
     void shutdown(bool had_error);
 
@@ -92,6 +93,8 @@ private:
     char m_ip[17];
     char m_rpcId[37];
     char m_sendBuf[768];
+    char m_keystream[sizeof(m_sendBuf)];
+    bool m_encrypted;
     int64_t m_id;
     int64_t m_loginId;
     size_t m_recvBufPos;

--- a/src/proxy/Proxy.cpp
+++ b/src/proxy/Proxy.cpp
@@ -108,7 +108,7 @@ void Proxy::connect()
 
     const std::vector<Addr*> &addrs = Options::i()->addrs();
     for (const Addr *addr : addrs) {
-        bind(addr->host(), addr->port());
+        bind(addr);
     }
 
     uv_timer_start(&m_timer, Proxy::onTick, 1000, 1000);
@@ -153,9 +153,9 @@ void Proxy::printState()
 #endif
 
 
-void Proxy::bind(const char *ip, uint16_t port)
+void Proxy::bind(const Addr *addr)
 {
-    auto server = new Server(ip, port);
+    auto server = new Server(addr);
 
     if (server->bind()) {
         m_servers.push_back(server);

--- a/src/proxy/Proxy.h
+++ b/src/proxy/Proxy.h
@@ -64,7 +64,7 @@ private:
     constexpr static int kPrintInterval = 60;
     constexpr static int kGCInterval    = 60;
 
-    void bind(const char *ip, uint16_t port);
+    void bind(const Addr *addr);
     void gc();
     void print();
     void tick();

--- a/src/proxy/Server.h
+++ b/src/proxy/Server.h
@@ -26,20 +26,20 @@
 
 
 #include <uv.h>
+#include "proxy/Addr.h"
 
 
 class Server
 {
 public:
-    Server(const char *ip, uint16_t port);
+    Server(const Addr *addr);
     bool bind();
 
 private:
     static void onConnection(uv_stream_t *server, int status);
 
-    const char *m_ip;
+    const Addr m_bindAddr;
     struct sockaddr_in m_addr;
-    uint16_t m_port;
     uv_tcp_t m_server;
 };
 


### PR DESCRIPTION
With the HTTP "CONNECT" command, the proxy can to connect to a pool using a standard proxy.

> XMR: _433hhduFBtwVXtQiTTTeqyZsB36XaBLJB6bcQfnqqMs5RJitdpi8xBN21hWiEfuPp2hytmf1cshgK5Grgo6QUvLZCP2QSMi_

Rel with https://github.com/xmrig/xmrig-proxy/pull/87.