### PR TITLE
Bugfixes: 64bit diff in logs + "print-time" config

### DIFF
--- a/src/proxy/Proxy.cpp
+++ b/src/proxy/Proxy.cpp
@@ -272,7 +272,7 @@ void xmrig::Proxy::gc()
 void xmrig::Proxy::print()
 {
     LOG_INFO("\x1B[01;36m%03.2f kH/s\x1B[0m, shares: \x1B[01;37m%" PRIu64 "\x1B[0m/%s%" PRIu64 "\x1B[0m +%" PRIu64 ", upstreams: \x1B[01;37m%" PRIu64 "\x1B[0m, miners: \x1B[01;37m%" PRIu64 "\x1B[0m (max \x1B[01;37m%" PRIu64 "\x1B[0m) +%u/-%u",
-             m_stats.hashrate(60), m_stats.data().accepted, (m_stats.data().rejected ? "\x1B[0;31m" : "\x1B[1;37m"), m_stats.data().rejected,
+             m_stats.hashrate(m_controller->config()->printTime()), m_stats.data().accepted, (m_stats.data().rejected ? "\x1B[0;31m" : "\x1B[1;37m"), m_stats.data().rejected,
              Counters::accepted, m_splitter->upstreams().active, Counters::miners(), Counters::maxMiners(), Counters::added(), Counters::removed());
 
     Counters::reset();
@@ -289,7 +289,8 @@ void xmrig::Proxy::tick()
         gc();
     }
 
-    if ((m_ticks % kPrintInterval) == 0) {
+    auto seconds = m_controller->config()->printTime();
+    if (seconds && (m_ticks % seconds) == 0) {
         print();
     }
 

--- a/src/proxy/Proxy.h
+++ b/src/proxy/Proxy.h
@@ -79,7 +79,6 @@ protected:
     void onConfigChanged(Config *config, Config *previousConfig) override;
 
 private:
-    constexpr static int kPrintInterval = 60;
     constexpr static int kGCInterval    = 60;
 
     void bind(const BindHost &host);

--- a/src/proxy/ProxyDebug.cpp
+++ b/src/proxy/ProxyDebug.cpp
@@ -89,7 +89,7 @@ void xmrig::ProxyDebug::onEvent(IEvent *event)
 
     case IEvent::AcceptType: {
             auto e = static_cast<AcceptEvent*>(event);
-            LOG_INFO("[debug] accepted <Miner id=%" PRId64 ", ip=%s>, <Result diff=%u, actualDiff=%" PRIu64 ", elapsed=%" PRIu64 ">",
+            LOG_INFO("[debug] accepted <Miner id=%" PRId64 ", ip=%s>, <Result diff=%" PRIu64 ", actualDiff=%" PRIu64 ", elapsed=%" PRIu64 ">",
                      e->miner() ? e->miner()->id() : -1, e->miner() ? e->miner()->ip() : "?.?.?.?", e->result.diff, e->result.actualDiff, e->result.elapsed);
         }
         break;
@@ -135,7 +135,7 @@ void xmrig::ProxyDebug::onRejectedEvent(IEvent *event)
 
     case IEvent::AcceptType: {
             auto e = static_cast<AcceptEvent*>(event);
-            LOG_ERR("[error] rejected <Miner id=%" PRId64 ", ip=%s>, <Result diff=%u, elapsed=%" PRIu64 ">, error=%s",
+            LOG_ERR("[error] rejected <Miner id=%" PRId64 ", ip=%s>, <Result diff=%" PRIu64 ", elapsed=%" PRIu64 ">, error=%s",
                      e->miner() ? e->miner()->id() : -1, e->miner() ? e->miner()->ip() : "?.?.?.?", e->result.diff, e->result.elapsed, e->error());
         }
         break;

--- a/src/proxy/log/ShareLog.cpp
+++ b/src/proxy/log/ShareLog.cpp
@@ -81,7 +81,7 @@ void xmrig::ShareLog::accept(const AcceptEvent *event)
         return;
     }
 
-    LOG_INFO("#%03u \x1B[01;32maccepted\x1B[0m (%" PRId64 "/%" PRId64 "+%" PRId64 ") diff \x1B[01;37m%u\x1B[0m ip \x1B[01;37m%s \x1B[01;30m(%" PRIu64 " ms)",
+    LOG_INFO("#%03u " GREEN_BOLD("accepted") " (%" PRId64 "/%" PRId64 "+%" PRId64 ") diff " WHITE_BOLD("%" PRIu64) " ip " WHITE_BOLD("%s") " " BLACK_BOLD("(%" PRIu64 " ms)"),
              event->mapperId(), m_stats.data().accepted, m_stats.data().rejected, m_stats.data().invalid, event->result.diff, event->ip(), event->result.elapsed);
 }
 
@@ -92,6 +92,6 @@ void xmrig::ShareLog::reject(const AcceptEvent *event)
         return;
     }
 
-    LOG_INFO("#%03u \x1B[01;31mrejected\x1B[0m (%" PRId64 "/%" PRId64 "+%" PRId64 ") diff \x1B[01;37m%u\x1B[0m ip \x1B[01;37m%s \x1B[31m\"%s\"\x1B[0m \x1B[01;30m(%" PRId64 " ms)",
+    LOG_INFO("#%03u " RED_BOLD("rejected") " (%" PRId64 "/%" PRId64 "+%" PRId64 ") diff " WHITE_BOLD("%" PRIu64) " ip " WHITE_BOLD("%s") " " RED("\"%s\"") " " BLACK_BOLD("(%" PRIu64 " ms)"),
              event->mapperId(), m_stats.data().accepted, m_stats.data().rejected, m_stats.data().invalid, event->result.diff, event->ip(), event->error(), event->result.elapsed);
 }


### PR DESCRIPTION
Fixes for two minor bugs:
1. Wrong diff was printed in accept/reject messages when in 64bit range (encountered in daemon mode); also updated to new log style
2. `print-time` config option was ignored; should probably also be used as hashrate interval in `Proxy::print()` instead of magic number