### PR TITLE
Use custom-diff shares for better proxy and worker stats

### DIFF
--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -115,6 +115,7 @@ public:
         AccessLogFileKey     = 'A',
         BindKey              = 'b',
         CustomDiffKey        = 1102,
+        CustomDiffStatsKey   = 1104,
         DebugKey             = 1101,
         ModeKey              = 'm',
         PoolCoinKey          = 'C',

--- a/src/config.json
+++ b/src/config.json
@@ -28,6 +28,7 @@
     ],
     "colors": true,
     "custom-diff": 0,
+    "custom-diff-stats": false,
     "donate-level": 0,
     "log-file": null,
     "mode": "nicehash",

--- a/src/core/config/Config.cpp
+++ b/src/core/config/Config.cpp
@@ -81,6 +81,7 @@ bool xmrig::Config::read(const IJsonReader &reader, const char *fileName)
         return false;
     }
 
+    m_customDiffStats = reader.getBool("custom-diff-stats", m_customDiffStats);
     m_debug        = reader.getBool("debug", m_debug);
     m_algoExt      = reader.getBool("algo-ext", m_algoExt);
     m_reuseTimeout = reader.getInt("reuse-timeout", m_reuseTimeout);
@@ -153,6 +154,7 @@ void xmrig::Config::getJSON(rapidjson::Document &doc) const
     doc.AddMember("bind",          bind, allocator);
     doc.AddMember("colors",        Log::isColors(), allocator);
     doc.AddMember("custom-diff",   diff(), allocator);
+    doc.AddMember("custom-diff-stats", m_customDiffStats, allocator);
     doc.AddMember("donate-level",  m_pools.donateLevel(), allocator);
     doc.AddMember("log-file",      m_logFile.toJSON(), allocator);
     doc.AddMember("mode",          StringRef(modeName()), allocator);

--- a/src/core/config/Config.h
+++ b/src/core/config/Config.h
@@ -80,6 +80,7 @@ public:
     void toggleVerbose();
 
     inline bool hasAlgoExt() const                 { return isDonateOverProxy() ? m_algoExt : true; }
+    inline bool isCustomDiffStats() const          { return m_customDiffStats; }
     inline bool isDebug() const                    { return m_debug; }
     inline bool isDonateOverProxy() const          { return m_pools.donateLevel() == 0 || m_mode == SIMPLE_MODE; }
     inline bool isShouldSave() const               { return m_upgrade && isAutoSave(); }
@@ -103,6 +104,7 @@ private:
 
     BindHosts m_bind;
     bool m_algoExt              = true;
+    bool m_customDiffStats      = false;
     bool m_debug                = false;
     int m_mode                  = NICEHASH_MODE;
     int m_reuseTimeout          = 0;

--- a/src/core/config/ConfigTransform.cpp
+++ b/src/core/config/ConfigTransform.cpp
@@ -66,6 +66,7 @@ void xmrig::ConfigTransform::transform(rapidjson::Document &doc, int key, const 
     case IConfig::ProxyPasswordKey: /* --access-password */
         return set(doc, "access-password", arg);
 
+    case IConfig::CustomDiffStatsKey: /* --custom-diff-stats */
     case IConfig::DebugKey:   /* --debug */
         return transformBoolean(doc, key, true);
 
@@ -109,6 +110,9 @@ void xmrig::ConfigTransform::transform(rapidjson::Document &doc, int key, const 
 void xmrig::ConfigTransform::transformBoolean(rapidjson::Document &doc, int key, bool enable)
 {
     switch (key) {
+    case IConfig::CustomDiffStatsKey: /* --custom-diff-stats */
+            return set(doc, "custom-diff-stats", enable);
+
     case IConfig::DebugKey: /* --debug */
         return set(doc, "debug", enable);
 

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -58,6 +58,7 @@ static struct option const options[] = {
     { "bind",              1, nullptr, IConfig::BindKey           },
     { "config",            1, nullptr, IConfig::ConfigKey         },
     { "custom-diff",       1, nullptr, IConfig::CustomDiffKey     },
+    { "custom-diff-stats", 0, nullptr, IConfig::CustomDiffStatsKey},
     { "debug",             0, nullptr, IConfig::DebugKey          },
     { "donate-level",      1, nullptr, IConfig::DonateLevelKey    },
     { "keepalive",         2, nullptr, IConfig::KeepAliveKey      },

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -52,6 +52,7 @@ Options:\n\
   -r, --retries=N           number of times to retry before switch to backup server (default: 1)\n\
   -R, --retry-pause=N       time to pause between retries (default: 1 second)\n\
       --custom-diff=N       override pool diff\n\
+      --custom-diff-stats   calculate stats using custom diff shares instead of pool shares\n\
       --reuse-timeout=N     timeout in seconds for reuse pool connections in simple mode\n\
       --verbose             verbose output\n\
       --user-agent=AGENT    set custom user-agent string for pool\n\

--- a/src/proxy/Miner.cpp
+++ b/src/proxy/Miner.cpp
@@ -30,6 +30,7 @@
 #include "base/io/json/Json.h"
 #include "base/io/log/Log.h"
 #include "base/net/stratum/Job.h"
+#include "base/net/stratum/SubmitResult.h"
 #include "base/tools/Buffer.h"
 #include "base/tools/Chrono.h"
 #include "base/tools/Handle.h"
@@ -39,6 +40,7 @@
 #include "proxy/Events.h"
 #include "proxy/events/CloseEvent.h"
 #include "proxy/events/LoginEvent.h"
+#include "proxy/events/AcceptEvent.h"
 #include "proxy/events/SubmitEvent.h"
 #include "proxy/Miner.h"
 #include "proxy/tls/TlsContext.h"
@@ -257,6 +259,10 @@ bool xmrig::Miner::parseRequest(int64_t id, const char *method, const rapidjson:
 
         if (event->error() == Error::NoError && m_customDiff && event->request.actualDiff() < m_diff) {
             success(id, "OK");
+
+            SubmitResult result = SubmitResult(1, m_customDiff, event->request.actualDiff(), event->request.id, 0);
+            AcceptEvent::start(m_mapperId, this, result, false, true);
+
             return true;
         }
 

--- a/src/proxy/Proxy.cpp
+++ b/src/proxy/Proxy.cpp
@@ -83,6 +83,7 @@ xmrig::Proxy::Proxy(Controller *controller) :
 
     m_splitter  = splitter;
     m_donate    = new DonateSplitter(controller);
+    m_stats     = new Stats(controller);
     m_shareLog  = new ShareLog(controller, m_stats);
     m_accessLog = new AccessLog(controller);
     m_workers   = new Workers(controller);
@@ -97,12 +98,12 @@ xmrig::Proxy::Proxy(Controller *controller) :
 #   endif
 
     Events::subscribe(IEvent::ConnectionType, m_miners);
-    Events::subscribe(IEvent::ConnectionType, &m_stats);
+    Events::subscribe(IEvent::ConnectionType, m_stats);
 
     Events::subscribe(IEvent::CloseType, m_miners);
     Events::subscribe(IEvent::CloseType, m_donate);
     Events::subscribe(IEvent::CloseType, splitter);
-    Events::subscribe(IEvent::CloseType, &m_stats);
+    Events::subscribe(IEvent::CloseType, m_stats);
     Events::subscribe(IEvent::CloseType, m_accessLog);
     Events::subscribe(IEvent::CloseType, m_workers);
 
@@ -110,16 +111,16 @@ xmrig::Proxy::Proxy(Controller *controller) :
     Events::subscribe(IEvent::LoginType, m_donate);
     Events::subscribe(IEvent::LoginType, &m_customDiff);
     Events::subscribe(IEvent::LoginType, splitter);
-    Events::subscribe(IEvent::LoginType, &m_stats);
+    Events::subscribe(IEvent::LoginType, m_stats);
     Events::subscribe(IEvent::LoginType, m_accessLog);
     Events::subscribe(IEvent::LoginType, m_workers);
 
     Events::subscribe(IEvent::SubmitType, m_donate);
     Events::subscribe(IEvent::SubmitType, splitter);
-    Events::subscribe(IEvent::SubmitType, &m_stats);
+    Events::subscribe(IEvent::SubmitType, m_stats);
     Events::subscribe(IEvent::SubmitType, m_workers);
 
-    Events::subscribe(IEvent::AcceptType, &m_stats);
+    Events::subscribe(IEvent::AcceptType, m_stats);
     Events::subscribe(IEvent::AcceptType, m_shareLog);
     Events::subscribe(IEvent::AcceptType, m_workers);
 
@@ -190,7 +191,7 @@ void xmrig::Proxy::printConnections()
 void xmrig::Proxy::printHashrate()
 {
     LOG_INFO("\x1B[01;32m* \x1B[01;37mspeed\x1B[0m \x1B[01;30m(1m) \x1B[01;36m%03.2f\x1B[0m, \x1B[01;30m(10m) \x1B[01;36m%03.2f\x1B[0m, \x1B[01;30m(1h) \x1B[01;36m%03.2f\x1B[0m, \x1B[01;30m(12h) \x1B[01;36m%03.2f\x1B[0m, \x1B[01;30m(24h) \x1B[01;36m%03.2f kH/s",
-             m_stats.hashrate(60), m_stats.hashrate(600), m_stats.hashrate(3600), m_stats.hashrate(3600 * 12), m_stats.hashrate(3600 * 24));
+             m_stats->hashrate(60), m_stats->hashrate(600), m_stats->hashrate(3600), m_stats->hashrate(3600 * 12), m_stats->hashrate(3600 * 24));
 }
 
 
@@ -208,7 +209,7 @@ void xmrig::Proxy::toggleDebug()
 
 const xmrig::StatsData &xmrig::Proxy::statsData() const
 {
-    return m_stats.data();
+    return m_stats->data();
 }
 
 
@@ -272,7 +273,7 @@ void xmrig::Proxy::gc()
 void xmrig::Proxy::print()
 {
     LOG_INFO("\x1B[01;36m%03.2f kH/s\x1B[0m, shares: \x1B[01;37m%" PRIu64 "\x1B[0m/%s%" PRIu64 "\x1B[0m +%" PRIu64 ", upstreams: \x1B[01;37m%" PRIu64 "\x1B[0m, miners: \x1B[01;37m%" PRIu64 "\x1B[0m (max \x1B[01;37m%" PRIu64 "\x1B[0m) +%u/-%u",
-             m_stats.hashrate(m_controller->config()->printTime()), m_stats.data().accepted, (m_stats.data().rejected ? "\x1B[0;31m" : "\x1B[1;37m"), m_stats.data().rejected,
+             m_stats->hashrate(m_controller->config()->printTime()), m_stats->data().accepted, (m_stats->data().rejected ? "\x1B[0;31m" : "\x1B[1;37m"), m_stats->data().rejected,
              Counters::accepted, m_splitter->upstreams().active, Counters::miners(), Counters::maxMiners(), Counters::added(), Counters::removed());
 
     Counters::reset();
@@ -281,7 +282,7 @@ void xmrig::Proxy::print()
 
 void xmrig::Proxy::tick()
 {
-    m_stats.tick(m_ticks, m_splitter);
+    m_stats->tick(m_ticks, m_splitter);
 
     m_ticks++;
 

--- a/src/proxy/Proxy.h
+++ b/src/proxy/Proxy.h
@@ -99,7 +99,7 @@ private:
     Miners *m_miners;
     ProxyDebug *m_debug;
     ShareLog *m_shareLog;
-    Stats m_stats;
+    Stats *m_stats;
     std::vector<Server*> m_servers;
     TlsContext *m_tls;
     uint64_t m_ticks;

--- a/src/proxy/Stats.cpp
+++ b/src/proxy/Stats.cpp
@@ -24,13 +24,16 @@
 
 
 #include "base/net/stratum/SubmitResult.h"
+#include "core/config/Config.h"
+#include "core/Controller.h"
 #include "Counters.h"
 #include "interfaces/ISplitter.h"
 #include "proxy/events/AcceptEvent.h"
 #include "proxy/Stats.h"
 
 
-xmrig::Stats::Stats() :
+xmrig::Stats::Stats(Controller *controller) :
+    m_controller(controller),
     m_hashrate(4)
 {
 }
@@ -107,7 +110,11 @@ void xmrig::Stats::onRejectedEvent(IEvent *event)
 
 void xmrig::Stats::accept(const AcceptEvent *event)
 {
-    m_hashrate.add(event->statsDiff());
+    if (event->isCustomDiff() && !m_controller->config()->isCustomDiffStats()) {
+        return;
+    }
+
+    m_hashrate.add(m_controller->config()->isCustomDiffStats() ? event->statsDiff() : event->result.diff);
 
     if (event->isCustomDiff()) {
         return;

--- a/src/proxy/Stats.cpp
+++ b/src/proxy/Stats.cpp
@@ -107,7 +107,7 @@ void xmrig::Stats::onRejectedEvent(IEvent *event)
 
 void xmrig::Stats::accept(const AcceptEvent *event)
 {
-    m_hashrate.add(event->result.diff);
+    m_hashrate.add(event->statsDiff());
 
     if (event->isCustomDiff()) {
         return;

--- a/src/proxy/Stats.cpp
+++ b/src/proxy/Stats.cpp
@@ -109,6 +109,10 @@ void xmrig::Stats::accept(const AcceptEvent *event)
 {
     m_hashrate.add(event->result.diff);
 
+    if (event->isCustomDiff()) {
+        return;
+    }
+
     m_data.accepted++;
     m_data.hashes += event->result.diff;
 

--- a/src/proxy/Stats.h
+++ b/src/proxy/Stats.h
@@ -38,13 +38,14 @@ namespace xmrig {
 
 
 class AcceptEvent;
+class Controller;
 class ISplitter;
 
 
 class Stats : public IEventListener
 {
 public:
-    Stats();
+    Stats(Controller *controller);
     ~Stats() override;
 
     void tick(uint64_t ticks, const ISplitter *splitter);
@@ -60,6 +61,7 @@ private:
     void accept(const AcceptEvent *event);
     void reject(const AcceptEvent *event);
 
+    Controller *m_controller;
     StatsData m_data;
     TickingCounter<uint32_t> m_hashrate;
 };

--- a/src/proxy/events/AcceptEvent.h
+++ b/src/proxy/events/AcceptEvent.h
@@ -26,14 +26,13 @@
 #define XMRIG_ACCEPTEVENT_H
 
 
+#include "base/net/stratum/SubmitResult.h"
+#include "proxy/Miner.h"
 #include "proxy/events/MinerEvent.h"
 #include "proxy/Error.h"
 
 
 namespace xmrig {
-
-
-class SubmitResult;
 
 
 class AcceptEvent : public MinerEvent
@@ -53,6 +52,7 @@ public:
     inline bool isRejected() const override { return m_error != nullptr; }
     inline const char *error() const        { return m_error; }
     inline size_t mapperId() const          { return m_mapperId; }
+    inline uint64_t statsDiff() const       { return (miner()->customDiff() ? std::min(miner()->customDiff(), result.diff) : result.diff); }
 
 
 protected:

--- a/src/proxy/events/AcceptEvent.h
+++ b/src/proxy/events/AcceptEvent.h
@@ -39,15 +39,16 @@ class SubmitResult;
 class AcceptEvent : public MinerEvent
 {
 public:
-    static inline bool start(size_t mapperId, Miner *miner, const SubmitResult &result, bool donate, const char *error = nullptr)
+    static inline bool start(size_t mapperId, Miner *miner, const SubmitResult &result, bool donate, bool customDiff, const char *error = nullptr)
     {
-        return exec(new (m_buf) AcceptEvent(mapperId, miner, result, donate, error));
+        return exec(new (m_buf) AcceptEvent(mapperId, miner, result, donate, customDiff, error));
     }
 
 
     const SubmitResult &result;
 
 
+    inline bool isCustomDiff() const        { return m_customDiff; }
     inline bool isDonate() const            { return m_donate; }
     inline bool isRejected() const override { return m_error != nullptr; }
     inline const char *error() const        { return m_error; }
@@ -55,9 +56,10 @@ public:
 
 
 protected:
-    inline AcceptEvent(size_t mapperId, Miner *miner, const SubmitResult &result, bool donate, const char *error)
+    inline AcceptEvent(size_t mapperId, Miner *miner, const SubmitResult &result, bool donate, bool customDiff, const char *error)
         : MinerEvent(AcceptType, miner),
           result(result),
+          m_customDiff(customDiff),
           m_donate(donate),
           m_error(error),
           m_mapperId(mapperId)
@@ -65,6 +67,7 @@ protected:
 
 
 private:
+    bool m_customDiff;
     bool m_donate;
     const char *m_error;
     size_t m_mapperId;

--- a/src/proxy/log/ShareLog.cpp
+++ b/src/proxy/log/ShareLog.cpp
@@ -77,7 +77,7 @@ void xmrig::ShareLog::onRejectedEvent(IEvent *event)
 
 void xmrig::ShareLog::accept(const AcceptEvent *event)
 {
-    if (!m_controller->config()->isVerbose() || event->isDonate()) {
+    if (!m_controller->config()->isVerbose() || event->isDonate() || event->isCustomDiff()) {
         return;
     }
 

--- a/src/proxy/log/ShareLog.cpp
+++ b/src/proxy/log/ShareLog.cpp
@@ -35,7 +35,7 @@
 #include "proxy/Stats.h"
 
 
-xmrig::ShareLog::ShareLog(Controller *controller, const Stats &stats) :
+xmrig::ShareLog::ShareLog(Controller *controller, Stats *stats) :
     m_stats(stats),
     m_controller(controller)
 {
@@ -82,7 +82,7 @@ void xmrig::ShareLog::accept(const AcceptEvent *event)
     }
 
     LOG_INFO("#%03u " GREEN_BOLD("accepted") " (%" PRId64 "/%" PRId64 "+%" PRId64 ") diff " WHITE_BOLD("%" PRIu64) " ip " WHITE_BOLD("%s") " " BLACK_BOLD("(%" PRIu64 " ms)"),
-             event->mapperId(), m_stats.data().accepted, m_stats.data().rejected, m_stats.data().invalid, event->result.diff, event->ip(), event->result.elapsed);
+             event->mapperId(), m_stats->data().accepted, m_stats->data().rejected, m_stats->data().invalid, event->result.diff, event->ip(), event->result.elapsed);
 }
 
 
@@ -93,5 +93,5 @@ void xmrig::ShareLog::reject(const AcceptEvent *event)
     }
 
     LOG_INFO("#%03u " RED_BOLD("rejected") " (%" PRId64 "/%" PRId64 "+%" PRId64 ") diff " WHITE_BOLD("%" PRIu64) " ip " WHITE_BOLD("%s") " " RED("\"%s\"") " " BLACK_BOLD("(%" PRIu64 " ms)"),
-             event->mapperId(), m_stats.data().accepted, m_stats.data().rejected, m_stats.data().invalid, event->result.diff, event->ip(), event->error(), event->result.elapsed);
+             event->mapperId(), m_stats->data().accepted, m_stats->data().rejected, m_stats->data().invalid, event->result.diff, event->ip(), event->error(), event->result.elapsed);
 }

--- a/src/proxy/log/ShareLog.h
+++ b/src/proxy/log/ShareLog.h
@@ -40,7 +40,7 @@ class Stats;
 class ShareLog : public IEventListener
 {
 public:
-    ShareLog(Controller *controller, const Stats &stats);
+    ShareLog(Controller *controller, Stats *stats);
     ~ShareLog() override;
 
 protected:
@@ -51,7 +51,7 @@ private:
     void accept(const AcceptEvent *event);
     void reject(const AcceptEvent *event);
 
-    const Stats &m_stats;
+    Stats *m_stats;
     Controller *m_controller;
 };
 

--- a/src/proxy/splitters/donate/DonateMapper.cpp
+++ b/src/proxy/splitters/donate/DonateMapper.cpp
@@ -117,7 +117,7 @@ void xmrig::DonateMapper::onLoginSuccess(IClient *)
 
 void xmrig::DonateMapper::onResultAccepted(IClient *, const SubmitResult &result, const char *error)
 {
-    AcceptEvent::start(m_id, m_miner, result, true, error);
+    AcceptEvent::start(m_id, m_miner, result, true, false, error);
 
     if (error) {
         m_miner->replyWithError(result.reqId, error);

--- a/src/proxy/splitters/nicehash/NonceMapper.cpp
+++ b/src/proxy/splitters/nicehash/NonceMapper.cpp
@@ -245,7 +245,7 @@ void xmrig::NonceMapper::onResultAccepted(IStrategy *, IClient *client, const Su
 {
     const SubmitCtx ctx = submitCtx(result.seq);
 
-    AcceptEvent::start(m_id, ctx.miner, result, client->id() == -1, error);
+    AcceptEvent::start(m_id, ctx.miner, result, client->id() == -1, false, error);
 
     if (!ctx.miner) {
         return;

--- a/src/proxy/splitters/simple/SimpleMapper.cpp
+++ b/src/proxy/splitters/simple/SimpleMapper.cpp
@@ -218,7 +218,7 @@ void xmrig::SimpleMapper::onPause(IStrategy *strategy)
 
 void xmrig::SimpleMapper::onResultAccepted(IStrategy *, IClient *client, const SubmitResult &result, const char *error)
 {
-    AcceptEvent::start(m_id, m_miner, result, client->id() == -1, error);
+    AcceptEvent::start(m_id, m_miner, result, client->id() == -1, false, error);
 
     if (!m_miner) {
         return;

--- a/src/proxy/workers/Worker.cpp
+++ b/src/proxy/workers/Worker.cpp
@@ -57,12 +57,12 @@ xmrig::Worker::Worker(size_t id, const std::string &name, const std::string &ip)
 }
 
 
-void xmrig::Worker::add(const SubmitResult &result)
+void xmrig::Worker::add(uint64_t diff)
 {
     m_accepted++;
-    m_hashes += result.diff;
+    m_hashes += diff;
 
-    m_hashrate.add(result.diff);
+    m_hashrate.add(diff);
 
     using namespace std::chrono;
     m_lastHash = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();

--- a/src/proxy/workers/Worker.h
+++ b/src/proxy/workers/Worker.h
@@ -44,7 +44,7 @@ public:
     Worker();
     Worker(size_t id, const std::string &name, const std::string &ip);
 
-    void add(const SubmitResult &result);
+    void add(uint64_t diff);
     void tick(uint64_t ticks);
 
     inline const char *ip() const             { return m_ip.c_str(); }

--- a/src/proxy/workers/Worker.h
+++ b/src/proxy/workers/Worker.h
@@ -35,9 +35,6 @@
 namespace xmrig {
 
 
-class SubmitResult;
-
-
 class Worker
 {
 public:

--- a/src/proxy/workers/Workers.cpp
+++ b/src/proxy/workers/Workers.cpp
@@ -301,7 +301,7 @@ void xmrig::Workers::accept(const AcceptEvent *event)
 
     Worker &worker = m_workers[index];
     if (!event->isRejected()) {
-        worker.add(event->result);
+        worker.add(event->statsDiff());
     }
     else {
         worker.reject(false);

--- a/src/proxy/workers/Workers.cpp
+++ b/src/proxy/workers/Workers.cpp
@@ -294,6 +294,10 @@ size_t xmrig::Workers::add(const Miner *miner)
 
 void xmrig::Workers::accept(const AcceptEvent *event)
 {
+    if (event->isCustomDiff() && !m_controller->config()->isCustomDiffStats()) {
+        return;
+    }
+
     size_t index = 0;
     if (!indexByMiner(event->miner(), &index)) {
         return;
@@ -301,7 +305,7 @@ void xmrig::Workers::accept(const AcceptEvent *event)
 
     Worker &worker = m_workers[index];
     if (!event->isRejected()) {
-        worker.add(event->statsDiff());
+        worker.add(m_controller->config()->isCustomDiffStats() ? event->statsDiff() : event->result.diff);
     }
     else {
         worker.reject(false);


### PR DESCRIPTION
# Objective
**In daemon mode**, a share is only accepted when a block is successfully mined. Therefore, **the statistics show zero hashrate most of the time** (for the proxy and all of the workers), **making them almost useless. This PR provides a solution to this problem.** It can also be used to improve the statistics for high difficulty upstream connections.

# Proposal
When the `custom-diff` feature is enabled, more shares are submitted to the proxy, carrying valuable information about the actual hashrate of the workers. Currently, this information is discarded.

Using the existing `AcceptEvent`, an update of the statistics can be triggered for incoming shares at the `custom-diff` level. Flagging the event via its new member `isCustomDiff()` ensures correct handling by the associated subscribers.

# Result
With `custom-diff` enabled, the proxy is able to calculate the actual hashrate although no shares are accepted by the daemon.

**Setup:**
* Proxy connected to Monero daemon for high difficulty
* one active worker with 2 kH/s hashrate (reported by XMRig)
* `custom-diff` set to 5000 for meaningful stats within 10 minutes

_Side effect (may be desired):_ The worker stats now show the same accepted shares count as the miner software of the worker and not only the count of shares sucessfully passed upstream.
```
[20:17:10.492] #000 use daemon localhost:18081  127.0.0.1 
[20:17:10.492] #000 new job from localhost:18081 diff 113801973557 algo rx/0 height 1998253
[20:18:10.613] 2.00 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +1/-0
[20:18:38.743] #000 new job from localhost:18081 diff 113647291429 algo rx/0 height 1998254
[20:19:10.730] 1.83 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:20:10.867] 2.08 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:21:10.987] 2.25 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:21:40.172] #000 new job from localhost:18081 diff 113805628935 algo rx/0 height 1998255
[20:22:05.089] #000 new job from localhost:18081 diff 113747545689 algo rx/0 height 1998256
[20:22:11.070] 2.08 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:23:11.205] 1.83 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:24:11.296] 1.92 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:25:02.408] #000 new job from localhost:18081 diff 113656280473 algo rx/0 height 1998257
[20:25:11.403] 2.00 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:26:10.591] #000 new job from localhost:18081 diff 113791206739 algo rx/0 height 1998258
[20:26:11.530] 2.33 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:26:29.630] #000 new job from localhost:18081 diff 114082948766 algo rx/0 height 1998259
[20:27:11.664] 1.67 kH/s, shares: 0/0 +0, upstreams: 1, miners: 1 (max 1) +0/-0
[20:27:25.512] * speed (1m) 1.58, (10m) 2.02, (1h) 0.34, (12h) 0.03, (24h) 0.01 kH/s
WORKER NAME     | LAST IP         | COUNT | ACCEPTED | REJ |  10 MINUTES |    24 HOURS |
test            | 127.0.0.1       |     1 |      247 |   0 |   2.02 kH/s |   0.01 kH/s |
```