### PR TITLE
Memory leak in xmrig::Proxy

### DIFF
--- a/src/proxy/Proxy.cpp
+++ b/src/proxy/Proxy.cpp
@@ -147,6 +147,7 @@ xmrig::Proxy::~Proxy()
     delete m_login;
     delete m_miners;
     delete m_splitter;
+    delete m_stats;
     delete m_shareLog;
     delete m_accessLog;
     delete m_debug;


### PR DESCRIPTION
Delete m_stats in destructor of xmrig::Proxy