### PR TITLE
Fix extra nonce for new miners

### DIFF
--- a/src/proxy/splitters/extra_nonce/ExtraNonceStorage.cpp
+++ b/src/proxy/splitters/extra_nonce/ExtraNonceStorage.cpp
@@ -33,7 +33,8 @@ bool xmrig::ExtraNonceStorage::add(Miner *miner)
     m_miners[miner->id()] = miner;
 
     if (isActive()) {
-        miner->setJob(m_job, m_miners.size() - 1);
+        miner->setJob(m_job, m_extraNonce);
+        ++m_extraNonce;
     }
 
     return true;
@@ -91,11 +92,11 @@ void xmrig::ExtraNonceStorage::setJob(const Job &job)
 
     m_job = job;
 
-    int64_t extra_nonce = 0;
+    m_extraNonce = 0;
 
     for (const auto& m : m_miners) {
-        m.second->setJob(m_job, extra_nonce);
-        ++extra_nonce;
+        m.second->setJob(m_job, m_extraNonce);
+        ++m_extraNonce;
     }
 }
 

--- a/src/proxy/splitters/extra_nonce/ExtraNonceStorage.h
+++ b/src/proxy/splitters/extra_nonce/ExtraNonceStorage.h
@@ -66,6 +66,7 @@ private:
     Job m_job;
     Job m_prevJob;
     std::map<int64_t, Miner*> m_miners;
+    int64_t m_extraNonce = 0;
 };
 
 


### PR DESCRIPTION
When a miner leaves and then another miner joins, it could receive one of already used extra_nonce values. The fix makes extra_nonce increase always until new job is received.