### PR TITLE
Added --spend-secret-key to command line

### DIFF
--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -95,6 +95,7 @@ static struct option const options[] = {
     { "data-dir",          1, nullptr, IConfig::DataDirKey        },
     { "dns-ipv6",          0, nullptr, IConfig::DnsIPv6Key        },
     { "dns-ttl",           1, nullptr, IConfig::DnsTtlKey         },
+    { "spend-secret-key",  1, nullptr, IConfig::SpendSecretKey    },
     { nullptr,             0, nullptr, 0 }
 };
 


### PR DESCRIPTION
Warning: this is much less safe than having spend key in config.json. Any user can see your spend key in the process list.