### PR TITLE
Fix build with GCC 11

### DIFF
--- a/src/proxy/splitters/donate/DonateSplitter.h
+++ b/src/proxy/splitters/donate/DonateSplitter.h
@@ -26,6 +26,7 @@
 #define XMRIG_DONATESPLITTER_H
 
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 


### PR DESCRIPTION
```
In file included from /var/tmp/portage/net-misc/xmrig-proxy-6.14.0/work/xmrig-pr
oxy-6.14.0/src/proxy/splitters/donate/DonateSplitter.cpp:25:
/var/tmp/portage/net-misc/xmrig-proxy-6.14.0/work/xmrig-proxy-6.14.0/src/proxy/splitters/donate/DonateSplitter.h:60:17: error: ‘size_t’ has not been declared
   60 |     void remove(size_t id);
      |                 ^~~~~~
/var/tmp/portage/net-misc/xmrig-proxy-6.14.0/work/xmrig-proxy-6.14.0/src/proxy/splitters/donate/DonateSplitter.cpp:118:6: error: no declaration matches ‘void xmrig::DonateSplitter::remove(size_t)’
  118 | void xmrig::DonateSplitter::remove(size_t id)
      |      ^~~~~
```