### PR TITLE
ZeroMQ support for solo mining

### DIFF
--- a/src/base/base.cmake
+++ b/src/base/base.cmake
@@ -70,6 +70,7 @@ set(HEADERS_BASE
     src/base/net/tools/Storage.h
     src/base/tools/Arguments.h
     src/base/tools/Baton.h
+    src/base/tools/bswap_64.h
     src/base/tools/Buffer.h
     src/base/tools/Chrono.h
     src/base/tools/Cvt.h

--- a/src/base/kernel/config/BaseTransform.cpp
+++ b/src/base/kernel/config/BaseTransform.cpp
@@ -242,13 +242,14 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
         return set(doc, BaseConfig::kTls, TlsConfig::kGen, arg);
 #   endif
 
-    case IConfig::RetriesKey:     /* --retries */
-    case IConfig::RetryPauseKey:  /* --retry-pause */
-    case IConfig::PrintTimeKey:   /* --print-time */
-    case IConfig::HttpPort:       /* --http-port */
-    case IConfig::DonateLevelKey: /* --donate-level */
-    case IConfig::DaemonPollKey:  /* --daemon-poll-interval */
-    case IConfig::DnsTtlKey:      /* --dns-ttl */
+    case IConfig::RetriesKey:       /* --retries */
+    case IConfig::RetryPauseKey:    /* --retry-pause */
+    case IConfig::PrintTimeKey:     /* --print-time */
+    case IConfig::HttpPort:         /* --http-port */
+    case IConfig::DonateLevelKey:   /* --donate-level */
+    case IConfig::DaemonPollKey:    /* --daemon-poll-interval */
+    case IConfig::DnsTtlKey:        /* --dns-ttl */
+    case IConfig::DaemonZMQPortKey: /* --daemon-zmq-port */
         return transformUint64(doc, key, static_cast<uint64_t>(strtol(arg, nullptr, 10)));
 
     case IConfig::BackgroundKey:  /* --background */
@@ -359,6 +360,9 @@ void xmrig::BaseTransform::transformUint64(rapidjson::Document &doc, int key, ui
 #   ifdef XMRIG_FEATURE_HTTP
     case IConfig::DaemonPollKey:  /* --daemon-poll-interval */
         return add(doc, Pools::kPools, Pool::kDaemonPollInterval, arg);
+
+    case IConfig::DaemonZMQPortKey:  /* --daemon-zmq-port */
+        return add(doc, Pools::kPools, Pool::kDaemonZMQPort, arg);
 #   endif
 
     default:

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -85,6 +85,7 @@ public:
         DnsIPv6Key           = 1053,
         DnsTtlKey            = 1054,
         SpendSecretKey       = 1055,
+        DaemonZMQPortKey     = 1056,
 
         // xmrig common
         CPUPriorityKey       = 1021,

--- a/src/base/net/stratum/DaemonClient.h
+++ b/src/base/net/stratum/DaemonClient.h
@@ -27,11 +27,16 @@
 #define XMRIG_DAEMONCLIENT_H
 
 
+#include <uv.h>
+
+
+#include "base/kernel/interfaces/IDnsListener.h"
 #include "base/kernel/interfaces/IHttpListener.h"
 #include "base/kernel/interfaces/ITimerListener.h"
 #include "base/net/stratum/BaseClient.h"
 #include "base/tools/Object.h"
 #include "base/tools/cryptonote/BlockTemplate.h"
+#include "base/net/tools/Storage.h"
 
 
 #include <memory>
@@ -40,7 +45,10 @@
 namespace xmrig {
 
 
-class DaemonClient : public BaseClient, public ITimerListener, public IHttpListener
+class DnsRequest;
+
+
+class DaemonClient : public BaseClient, public IDnsListener, public ITimerListener, public IHttpListener
 {
 public:
     XMRIG_DISABLE_COPY_MOVE_DEFAULT(DaemonClient)
@@ -57,6 +65,7 @@ protected:
 
     void onHttpData(const HttpData &data) override;
     void onTimer(const Timer *timer) override;
+    void onResolved(const DnsRecords& records, int status, const char* error) override;
 
     inline bool hasExtension(Extension) const noexcept override         { return false; }
     inline const char *mode() const override                            { return "daemon"; }
@@ -64,7 +73,7 @@ protected:
     inline const char *tlsVersion() const override                      { return m_tlsVersion; }
     inline int64_t send(const rapidjson::Value &, Callback) override    { return -1; }
     inline int64_t send(const rapidjson::Value &) override              { return -1; }
-    inline void deleteLater() override                                  { delete this; }
+    void deleteLater() override;
     inline void tick(uint64_t) override                                 {}
 
 private:
@@ -95,6 +104,38 @@ private:
     String m_blocktemplateRequestHash;
 
     BlockTemplate m_blocktemplate;
+
+private:
+    static inline DaemonClient* getClient(void* data) { return m_storage.get(data); }
+
+    uintptr_t m_key = 0;
+    static Storage<DaemonClient> m_storage;
+
+    static void onZMQConnect(uv_connect_t* req, int status);
+    static void onZMQRead(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf);
+    static void onZMQClose(uv_handle_t* handle);
+    static void onZMQShutdown(uv_handle_t* handle);
+
+    void ZMQConnected();
+    bool ZMQWrite(const char* data, size_t size);
+    void ZMQRead(ssize_t nread, const uv_buf_t* buf);
+    void ZMQParse();
+    bool ZMQClose(bool shutdown = false);
+
+    std::shared_ptr<DnsRequest> m_dns;
+    uv_tcp_t* m_ZMQSocket = nullptr;
+
+    enum {
+        ZMQ_NOT_CONNECTED,
+        ZMQ_GREETING_1,
+        ZMQ_GREETING_2,
+        ZMQ_HANDSHAKE,
+        ZMQ_CONNECTED,
+        ZMQ_DISCONNECTING,
+    } m_ZMQConnectionState = ZMQ_NOT_CONNECTED;
+
+    std::vector<char> m_ZMQSendBuf;
+    std::vector<char> m_ZMQRecvBuf;
 };
 
 

--- a/src/base/net/stratum/Pool.cpp
+++ b/src/base/net/stratum/Pool.cpp
@@ -66,6 +66,7 @@ const char *Pool::kAlgo                   = "algo";
 const char *Pool::kCoin                   = "coin";
 const char *Pool::kDaemon                 = "daemon";
 const char *Pool::kDaemonPollInterval     = "daemon-poll-interval";
+const char *Pool::kDaemonZMQPort          = "daemon-zmq-port";
 const char *Pool::kEnabled                = "enabled";
 const char *Pool::kFingerprint            = "tls-fingerprint";
 const char *Pool::kKeepalive              = "keepalive";
@@ -127,6 +128,7 @@ xmrig::Pool::Pool(const rapidjson::Value &object) :
     m_coin           = Json::getString(object, kCoin);
     m_daemon         = Json::getString(object, kSelfSelect);
     m_proxy          = Json::getValue(object, kSOCKS5);
+    m_zmqPort        = Json::getInt(object, kDaemonZMQPort, m_zmqPort);
 
     m_flags.set(FLAG_ENABLED,  Json::getBool(object, kEnabled, true));
     m_flags.set(FLAG_NICEHASH, Json::getBool(object, kNicehash) || m_url.host().contains(kNicehashHost));
@@ -301,6 +303,7 @@ rapidjson::Value xmrig::Pool::toJSON(rapidjson::Document &doc) const
 
     if (m_mode == MODE_DAEMON) {
         obj.AddMember(StringRef(kDaemonPollInterval), m_pollInterval, allocator);
+        obj.AddMember(StringRef(kDaemonZMQPort), m_zmqPort, allocator);
     }
     else {
         obj.AddMember(StringRef(kSelfSelect),     m_daemon.url().toJSON(), allocator);
@@ -336,6 +339,9 @@ void xmrig::Pool::print() const
     LOG_NOTICE("url:       %s", url().data());
     LOG_DEBUG ("host:      %s", host().data());
     LOG_DEBUG ("port:      %d", static_cast<int>(port()));
+    if (m_zmqPort >= 0) {
+        LOG_DEBUG("zmq-port:  %d", m_zmqPort);
+    }
     LOG_DEBUG ("user:      %s", m_user.data());
     LOG_DEBUG ("pass:      %s", m_password.data());
     LOG_DEBUG ("rig-id     %s", m_rigId.data());

--- a/src/base/net/stratum/Pool.h
+++ b/src/base/net/stratum/Pool.h
@@ -72,6 +72,7 @@ public:
     static const char *kUrl;
     static const char *kUser;
     static const char* kSpendSecretKey;
+    static const char* kDaemonZMQPort;
     static const char *kNicehashHost;
 
     constexpr static int kKeepAliveTimeout         = 60;
@@ -107,6 +108,7 @@ public:
     inline int keepAlive() const                        { return m_keepAlive; }
     inline Mode mode() const                            { return m_mode; }
     inline uint16_t port() const                        { return m_url.port(); }
+    inline int zmq_port() const                         { return m_zmqPort; }
     inline uint64_t pollInterval() const                { return m_pollInterval; }
     inline void setAlgo(const Algorithm &algorithm)     { m_algorithm = algorithm; }
     inline void setPassword(const String &password)     { m_password = password; }
@@ -155,6 +157,7 @@ private:
     uint64_t m_pollInterval         = kDefaultPollInterval;
     Url m_daemon;
     Url m_url;
+    int m_zmqPort                   = -1;
 
 #   ifdef XMRIG_FEATURE_BENCHMARK
     std::shared_ptr<BenchConfig> m_benchmark;

--- a/src/base/tools/bswap_64.h
+++ b/src/base/tools/bswap_64.h
@@ -1,0 +1,37 @@
+/* XMRig
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef XMRIG_BSWAP_64_H
+#define XMRIG_BSWAP_64_H
+
+#ifdef _MSC_VER
+
+#include <stdlib.h>
+#define bswap_64(x) _byteswap_uint64(x)
+
+#elif defined __GNUC__
+
+#define bswap_64(x) __builtin_bswap64(x)
+
+#else
+
+#include <byteswap.h>
+
+#endif
+
+#endif /* XMRIG_BSWAP_64_H */


### PR DESCRIPTION
Gets new blocks from daemon immediately without polling, saving ~0.5 seconds on average when daemon gets new block from the network. Also saves some CPU cycles because it doesn't need to poll daemon every second.

Testing: add "daemon-zmq-port": 28083 to proxy's pool config in config.json and run ./monerod --testnet --zmq-pub tcp://127.0.0.1:28083