### PR TITLE
Update link text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This proxy designed and created for handle donation traffic from XMRig. No one o
 ## Usage
 :boom: If you use Linux and want handle more than **1000 connections**, you need [increase limits of open files](https://github.com/xmrig/xmrig-proxy/wiki/Ubuntu-setup).
 
-Use [config.xmrig.com](https://config.xmrig.com/proxy) to generate, edit or share configurations.
+Use [config.xmrig.com/proxy](https://config.xmrig.com/proxy) to generate, edit or share configurations.
   
 ### Options
 ```


### PR DESCRIPTION
Showing the full link makes it more clear that the link goes directly to the proxy configurator