### PR TITLE
fix warning

### DIFF
--- a/src/base/io/Async.cpp
+++ b/src/base/io/Async.cpp
@@ -26,7 +26,7 @@
 // since 2019.05.16, Version 1.29.0 (Stable) https://github.com/xmrig/xmrig/pull/1889
 #if (UV_VERSION_MAJOR >= 1) && (UV_VERSION_MINOR >= 29) && defined(__linux__)
 #include <sys/eventfd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 #include <cstdlib>
 


### PR DESCRIPTION
this fixes a warning seen when compiling on alpine
`In file included from /xmrig-proxy/src/base/io/Async.cpp:29:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      |  ^~~~~~~`